### PR TITLE
Ignore ruby dependency

### DIFF
--- a/org-inherited-config.json
+++ b/org-inherited-config.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "labels": ["dependencies"],
-  "assigneesFromCodeOwners": true
+  "assigneesFromCodeOwners": true,
+  "ignoreDeps": ["ruby"]
 }


### PR DESCRIPTION
We carefully handle the Ruby dependency, and renovate wants to upgrade it to a patch version as soon as a new version comes out. This change will prevent that.

@jrafanie Please review.

This should remove PRs like the following, which we would never merge anyway.

- https://github.com/ManageIQ/guides/pull/595
- https://github.com/ManageIQ/manageiq-providers-amazon/pull/935
- https://github.com/ManageIQ/manageiq-documentation/pull/1885
- https://github.com/ManageIQ/manageiq-rpm_build/pull/603
- https://github.com/ManageIQ/manageiq.github.io/pull/26
- https://github.com/ManageIQ/miq_bot/pull/893
- https://github.com/ManageIQ/manageiq/pull/23712